### PR TITLE
Fix failure of make command

### DIFF
--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -38,13 +38,14 @@ export CONTAINER_NAME= {{ cookiecutter.project_slug }}
 export DATA={{ cookiecutter.data_source }}
 export JUPYTER_HOST_PORT={{ cookiecutter.jupyter_host_port }}
 export JUPYTER_CONTAINER_PORT=8888
+export PYTHON=python3
 
 ###########################################################################################################
 ## TARGETS
 ###########################################################################################################
 
 help:
-	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+	@$(PYTHON) -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
 init: init-docker init-data ## initialize repository for traning
 
@@ -66,7 +67,7 @@ jupyter: ## start Jupyter Notebook server
 	jupyter-notebook --ip=0.0.0.0 --port=${JUPYTER_CONTAINER_PORT}
 
 test: ## run test cases in tests directory
-	python -m unittest discover
+	$(PYTHON) -m unittest discover
 
 lint: ## check style with flake8
 	flake8 {{ cookiecutter.project_slug }}

--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile
@@ -18,9 +18,6 @@ RUN pip install -r /requirements.txt
 RUN useradd docker -u 1000 -s /bin/bash -m
 USER docker
 
-RUN echo "alias python=python3" >> $HOME/.bashrc && \
-    echo "alias pip=pip3" >> $HOME/.bashrc
-
 WORKDIR /work
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Fix #49 

With this patch, make command succeeded as follows.

```
$make create-container JUPYTER_HOST_PORT=9920
docker run -it -v /Users/takahi-i/IdeaProjects/aho:/work -p 9920:8888 --name aho aho
docker@fedf47c0075b:/work$ make
init                 initialize repository for traning
init-data            download data
init-docker          initialize docker image
create-container     create docker container
start-container      start docker container
jupyter              start Jupyter Notebook server
test                 run test cases in tests directory
lint                 check style with flake8
profile              show profile of the project
clean                remove all artifacts
clean-model          remove model artifacts
clean-pyc            remove Python file artifacts
distclean            remove all the reproducible resources including Docker images
clean-data           remove files under data
clean-docker         remove Docker image and container
```