### PR TITLE
Fixbug when sudo is used in make create-container

### DIFF
--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -30,6 +30,7 @@ export DOCKER=nvidia-docker
 {% else %}
 export DOCKER=docker
 {%- endif %}
+export PWD=`pwd`
 export PRINT_HELP_PYSCRIPT
 export START_DOCKER_CONTAINER
 export PYTHONPATH=$PYTHONPATH:$(PWD)


### PR DESCRIPTION
If we execute `sudo make create-container`, `PWD` is empty.
This causes that we cannot copy contents of repository to the docker instance. 
So I explicitly declare the PWD variable with the below command.
> PWD=`pwd`