### PR TITLE
Add resources for development and release

### DIFF
--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -56,13 +56,16 @@ export PRINT_HELP_PYSCRIPT
 export START_DOCKER_CONTAINER
 export PYTHONPATH=$PYTHONPATH:$(PWD)
 export PROJECT_NAME={{ cookiecutter.project_slug }}
-export IMAGE_NAME=$(PROJECT_NAME)-image
-export CONTAINER_NAME=$(PROJECT_NAME)-container
+export MODE=dev ## dev or release
+export BASE_DOCKERFILE=docker/Dockerfile
+export DOCKERFILE=$(BASE_DOCKERFILE).$(MODE)
+export BASE_IMAGE_NAME=$(PROJECT_NAME)-image-base
+export IMAGE_NAME=$(PROJECT_NAME)-$(MODE)-image
+export CONTAINER_NAME=$(PROJECT_NAME)-$(MODE)-container
 export DATA_SOURCE={{ cookiecutter.data_source }}
 export JUPYTER_HOST_PORT={{ cookiecutter.jupyter_host_port }}
 export JUPYTER_CONTAINER_PORT=8888
 export PYTHON=python3
-export DOCKERFILE=docker/Dockerfile
 
 ###########################################################################################################
 ## ADD TARGETS SPECIFIC TO "{{ cookiecutter.project_name }}"
@@ -88,10 +91,12 @@ sync-from-source: ## download data data source to local envrionment
 {% endif %}
 
 init-docker: ## initialize docker image
+	$(DOCKER) build -t $(BASE_IMAGE_NAME) -f $(BASE_DOCKERFILE) --build-arg UID=$(shell id -u) .
 	$(DOCKER) build -t $(IMAGE_NAME) -f $(DOCKERFILE) --build-arg UID=$(shell id -u) .
 
-init-docker-no-cache: ## initialize docker image without cachhe
-	$(DOCKER) build --no-cache -t $(IMAGE_NAME) -f $(DOCKERFILE) --build-arg UID=$(shell id -u) .
+init-docker-no-cache: ## initialize docker image without cache
+	$(DOCKER) build --no-cache -t $(BASE_IMAGE_NAME) -f $(BASE_DOCKERFILE) --build-arg UID=$(shell id -u) .
+	$(DOCKER) build -t $(IMAGE_NAME) -f $(DOCKERFILE) --build-arg UID=$(shell id -u) .
 
 sync-to-source: ## sync local data to data source
 {%- if cookiecutter.data_source_type == 's3' %}

--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -92,11 +92,11 @@ sync-from-source: ## download data data source to local envrionment
 
 init-docker: ## initialize docker image
 	$(DOCKER) build -t $(BASE_IMAGE_NAME) -f $(BASE_DOCKERFILE) --build-arg UID=$(shell id -u) .
-	$(DOCKER) build -t $(IMAGE_NAME) -f $(DOCKERFILE) --build-arg UID=$(shell id -u) .
+	$(DOCKER) build -t $(IMAGE_NAME) -f $(DOCKERFILE) .
 
 init-docker-no-cache: ## initialize docker image without cache
 	$(DOCKER) build --no-cache -t $(BASE_IMAGE_NAME) -f $(BASE_DOCKERFILE) --build-arg UID=$(shell id -u) .
-	$(DOCKER) build -t $(IMAGE_NAME) -f $(DOCKERFILE) --build-arg UID=$(shell id -u) .
+	$(DOCKER) build -t $(IMAGE_NAME) -f $(DOCKERFILE) .
 
 sync-to-source: ## sync local data to data source
 {%- if cookiecutter.data_source_type == 's3' %}

--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -56,7 +56,7 @@ export PRINT_HELP_PYSCRIPT
 export START_DOCKER_CONTAINER
 export PYTHONPATH=$PYTHONPATH:$(PWD)
 export PROJECT_NAME={{ cookiecutter.project_slug }}
-export MODE=dev ## dev or release
+export MODE=dev
 export BASE_DOCKERFILE=docker/Dockerfile
 export DOCKERFILE=$(BASE_DOCKERFILE).$(MODE)
 export BASE_IMAGE_NAME=$(PROJECT_NAME)-image-base

--- a/{{ cookiecutter.project_slug }}/docker/Dcokerfile.dev
+++ b/{{ cookiecutter.project_slug }}/docker/Dcokerfile.dev
@@ -1,0 +1,8 @@
+FROM {{ cookiecutter.project_slug }}.base
+
+COPY ./requirements_dev.txt /requirements_dev.txt
+RUN pip install -r /requirements_dev.txt
+
+WORKDIR /work
+
+ENTRYPOINT ["/bin/bash"]

--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile
@@ -18,7 +18,3 @@ RUN pip install -r /requirements.txt
 ARG UID
 RUN useradd docker -l -u $UID -s /bin/bash -m
 USER docker
-
-WORKDIR /work
-
-ENTRYPOINT ["/bin/bash"]

--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile.dev
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM {{ cookiecutter.project_slug }}.base
+FROM {{cookiecutter.project_slug}}-image-base
 
 COPY ./requirements_dev.txt /requirements_dev.txt
 RUN pip install -r /requirements_dev.txt

--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile.release
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile.release
@@ -1,0 +1,6 @@
+FROM {{ cookiecutter.project_slug }}.base
+
+COPY . /work
+WORKDIR /work
+
+ENTRYPOINT ["/bin/bash"]

--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile.release
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM {{ cookiecutter.project_slug }}.base
+FROM {{cookiecutter.project_slug}}-image-base
 
 COPY . /work
 WORKDIR /work

--- a/{{ cookiecutter.project_slug }}/requirements_dev.txt
+++ b/{{ cookiecutter.project_slug }}/requirements_dev.txt
@@ -1,0 +1,4 @@
+jupyter
+notebook
+Sphinx
+flake8


### PR DESCRIPTION
This pull request support mode in projects. Two modes (development and release) are supported. Both modes are derived from base mode.

Docker images for development  mode contain tools in developing phase such as linter or Jupyter Notebook and also mount the project top directories.

Images for release does not have developing tools, Image for release copy top directory of the project. This behavior is needed to deploy Kubernetes.
 