### PR TITLE
add formatter

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,5 +5,6 @@
     "description": "Please Input a short description",
     "data_source_type": ["s3", "nfs", "url"],
     "data_source": "Please Input data source",
-    "use_nvidia_docker": ["no", "yes"]
+    "use_nvidia_docker": ["no", "yes"],
+    "formatter_type": ["black", "autopep8", "yapf"]
 }

--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -148,3 +148,17 @@ clean-container: ## remove Docker container
 
 clean-image: ## remove Docker image
 	-$(DOCKER) image rm $(IMAGE_NAME)
+
+format:
+{%- if cookiecutter.formatter_type == 'black' %}
+	- black scripts
+	- black {{ cookiecutter.project_slug }}
+{%- elif cookiecutter.formatter_type == 'autopep8' %}
+	- autopep8 --in-place --recursive scripts
+	- autopep8 --in-place --recursive {{ cookiecutter.project_slug }}
+{%- elif cookiecutter.formatter_type == 'yapf' %}
+	- yapf --in-place --recursive scripts
+	- yapf --in-place --recursive {{ cookiecutter.project_slug }
+{%- elif cookiecutter.formatter_type == '' %}
+	echo "Formatter is not set."
+{% endif %}

--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -152,13 +152,13 @@ clean-image: ## remove Docker image
 format:
 {%- if cookiecutter.formatter_type == 'black' %}
 	- black scripts
-	- black {{ cookiecutter.project_slug }}
+	- black $(PROJECT_NAME)
 {%- elif cookiecutter.formatter_type == 'autopep8' %}
 	- autopep8 --in-place --recursive scripts
-	- autopep8 --in-place --recursive {{ cookiecutter.project_slug }}
+	- autopep8 --in-place --recursive $(PROJECT_NAME)
 {%- elif cookiecutter.formatter_type == 'yapf' %}
 	- yapf --in-place --recursive scripts
-	- yapf --in-place --recursive {{ cookiecutter.project_slug }
+	- yapf --in-place --recursive $(PROJECT_NAME)
 {%- elif cookiecutter.formatter_type == '' %}
 	echo "Formatter is not set."
 {% endif %}

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -74,6 +74,12 @@ When you see the status of Docker container, please run `make profile` in host m
 To launch Jupyter Notebook, please run `make jupyter` in the Docker container. After launch the Jupyter Notebook, you can
 access the Jupyter Notebook service in http://localhost:{{ cookiecutter.jupyter_host_port }}.
 
+{{%- if cookiecutter.formatter_type != '' -%}}
+### Run formatter
+When you format project's codes, please run `make format`.
+More details of {{ cookiecutter.formatter_type }} in {{%- if cookiecutter.formatter_type === 'black' -%}}https://github.com/psf/black {%- elif cookiecutter.formatter_type == 'autopep8' -%} https://github.com/hhatto/autopep8 {{%- elif cookiecutter.formatter_type === 'yapf' -%}}
+
+
 # Credits
 
 This package was created with [Cookiecutter](https://github.com/audreyr/cookiecutter) and the [cookiecutter-docker-science](https://docker-science.github.io/) project template.

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -74,10 +74,9 @@ When you see the status of Docker container, please run `make profile` in host m
 To launch Jupyter Notebook, please run `make jupyter` in the Docker container. After launch the Jupyter Notebook, you can
 access the Jupyter Notebook service in http://localhost:{{ cookiecutter.jupyter_host_port }}.
 
-{{%- if cookiecutter.formatter_type != '' -%}}
 ### Run formatter
 When you format project's codes, please run `make format`.
-More details of {{ cookiecutter.formatter_type }} in {{%- if cookiecutter.formatter_type === 'black' -%}}https://github.com/psf/black {%- elif cookiecutter.formatter_type == 'autopep8' -%} https://github.com/hhatto/autopep8 {{%- elif cookiecutter.formatter_type === 'yapf' -%}}
+More details of {{ cookiecutter.formatter_type }} in {%- if cookiecutter.formatter_type == 'black' %}https://github.com/psf/black {%- elif cookiecutter.formatter_type == 'autopep8' %} https://github.com/hhatto/autopep8 {%- elif cookiecutter.formatter_type == 'yapf' %} https://github.com/google/yapf {% endif %}
 
 
 # Credits

--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -5,3 +5,4 @@ jupyter
 notebook
 Sphinx
 flake8
+{{ cookiecutter.formatter_type }}


### PR DESCRIPTION
## Background.
There's an argument to be made about how the code looks.
This isn't a very productive argument, but it helps that the successor has a clean code!
Sometimes formatters are used to avoid this discussion and to formulate code that is in line with convention

## What I did.
 - Make option to choose one of three formatters: black, yapf and autopep8.
 - Added `make format` to Makefile.
 - Added information about the formatter in README.md
