### PR TITLE
Remove packages used only in development phases from requirements.txt

### DIFF
--- a/{{ cookiecutter.project_slug }}/requirements.txt
+++ b/{{ cookiecutter.project_slug }}/requirements.txt
@@ -1,8 +1,3 @@
 awscli
 click
-matplotlib
-jupyter
-notebook
-Sphinx
-flake8
 {{ cookiecutter.formatter_type }}

--- a/{{ cookiecutter.project_slug }}/requirements_dev.txt
+++ b/{{ cookiecutter.project_slug }}/requirements_dev.txt
@@ -1,3 +1,4 @@
+matplotlib
 jupyter
 notebook
 Sphinx


### PR DESCRIPTION
This pull request contains changes to reduce packages used only in development from the requirements.txt file which lists the packages in product images.

Ref https://github.com/docker-science/cookiecutter-docker-science/issues/94