### PR TITLE
no-cache option to build concrete image

### DIFF
--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -96,7 +96,7 @@ init-docker: ## initialize docker image
 
 init-docker-no-cache: ## initialize docker image without cache
 	$(DOCKER) build --no-cache -t $(BASE_IMAGE_NAME) -f $(BASE_DOCKERFILE) --build-arg UID=$(shell id -u) .
-	$(DOCKER) build -t $(IMAGE_NAME) -f $(DOCKERFILE) .
+	$(DOCKER) build --no-cache -t $(IMAGE_NAME) -f $(DOCKERFILE) .
 
 sync-to-source: ## sync local data to data source
 {%- if cookiecutter.data_source_type == 's3' %}


### PR DESCRIPTION
When I use `make init-docker-no-cache`, I often rebuild each concrete images(dev, release) without cache.

Please tell me your opinions.