### PR TITLE
Add path to /home/docker/.local/bin

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile
@@ -18,3 +18,5 @@ RUN pip install -r /requirements.txt
 ARG UID
 RUN useradd docker -l -u $UID -s /bin/bash -m
 USER docker
+
+ENV PATH=$PATH:/home/docker/.local/bin


### PR DESCRIPTION
Fix #99 

Without this fix, we are not able to run jupyter with `make jupyter` in the created containers with the following messages.

```
make jupyter
jupyter-notebook --ip=0.0.0.0 --port=8888
make: jupyter-notebook: Command not found
Makefile:102: recipe for target 'jupyter' failed
make: *** [jupyter] Error 127
```

Applying this patch fixes the path problem.
