### PR TITLE
Increase Python version to 3.8

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile
@@ -6,9 +6,9 @@ FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y \
   git \
-  python3.6 \
+  python3.8 \
   python3-pip \
-  python3.6-dev
+  python3.8-dev
 
 RUN pip3 install --upgrade pip
 


### PR DESCRIPTION
Hi, @jun-harashima @funwarioisii 

I would like to increase the version of Python in Docker containers build in Docker Science to 3.8, since Python 3.6 is eol in the end of this year.

 